### PR TITLE
Docker files to test locally

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Automation
+.github
+
+# Test cases
+go/
+js/
+php/

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -20,9 +20,13 @@ jobs:
         run: docker build --target js . -t aurelijusbanelis/callenge:js
       - name: Build for Go
         run: docker build --target go . -t aurelijusbanelis/callenge:go
-      - name: Notice about manual push
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: aurelijuschallengebot
+          password: ${{ secrets.DOCKERHUB_TOKEN_CHALLENGE_BOT }}
+      - name: Pushing latest images
         run: |
-          echo "Binaries are not pushed automatically. Please push manually to https://hub.docker.com/r/aurelijusbanelis/callenge"
-          echo "docker push aurelijusbanelis/callenge:php"
-          echo "docker push aurelijusbanelis/callenge:js"
-          echo "docker push aurelijusbanelis/callenge:go"
+          docker push aurelijusbanelis/callenge:php
+          docker push aurelijusbanelis/callenge:js
+          docker push aurelijusbanelis/callenge:go

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -1,0 +1,28 @@
+name: Smoke test for building docker images
+
+on:
+  push:
+    paths:
+      - 'Dockerfile'
+  pull_request:
+    paths:
+      - 'Dockerfile'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build for PHP
+        run: docker build --target php . -t aurelijusbanelis/callenge:php
+      - name: Build for JavaScript
+        run: docker build --target js . -t aurelijusbanelis/callenge:js
+      - name: Build for Go
+        run: docker build --target go . -t aurelijusbanelis/callenge:go
+      - name: Notice about manual push
+        run: |
+          echo "Binaries are not pushed automatically. Please push manually to https://hub.docker.com/r/aurelijusbanelis/callenge"
+          echo "docker push aurelijusbanelis/callenge:php"
+          echo "docker push aurelijusbanelis/callenge:js"
+          echo "docker push aurelijusbanelis/callenge:go"

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -1,4 +1,4 @@
-name: Smoke test for building docker images
+name: Building docker images to run challenge locally
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Prevent commiting binary while testing build commands
+challenge

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM golang:1.21.1-alpine3.18 as builder
+
+WORKDIR /app
+ADD . /app
+RUN go test main_test.go -c -o challenge
+RUN chmod +x challenge
+ENV LANGUAGE=go
+CMD ["/app/challenge"]
+
+FROM php:8.2-cli-alpine3.17 as php
+COPY --from=builder /app/challenge /opt/challenge
+COPY --from=builder /app/tests /opt/tests
+COPY --from=builder /app/run-php.sh /opt/run-php.sh
+VOLUME /opt/php
+WORKDIR /opt
+ENV LANGUAGE=php
+CMD ["/opt/challenge"]
+
+FROM golang:1.21.1-alpine3.18 as go
+COPY --from=builder /app/challenge /opt/challenge
+COPY --from=builder /app/tests /opt/tests
+COPY --from=builder /app/run-go.sh /opt/run-go.sh
+VOLUME /opt/go
+WORKDIR /opt
+ENV LANGUAGE=go
+CMD ["/opt/challenge"]
+
+FROM node:20.6.0-alpine3.18 as js
+COPY --from=builder /app/challenge /opt/challenge
+COPY --from=builder /app/tests /opt/tests
+COPY --from=builder /app/run-js.sh /opt/run-js.sh
+VOLUME /opt/js
+WORKDIR /opt
+ENV LANGUAGE=js
+CMD ["/opt/challenge"]
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,40 @@ Let's have fun and celebrate Programmer's day with this challenge.
  * Write code in you favorite language (see [`go`](go/main.go), [`js`](js/main.js), [`php`](php/main.php) folders)
  * Create a Pull request and see automated tests check your results 
 
+## Running tests locally
+
+### PHP 8.2
+
+```shell
+docker run -v ${PWD}/php:/opt/php aurelijusbanelis/callenge:php 
+```
+Where your code is in `php` folder with `php/main.php` file.
+
+### JavaScript (Node 20)
+
+```shell
+docker run -v ${PWD}/js:/opt/js aurelijusbanelis/callenge:js 
+```
+Where your code is in `js` folder with `js/main.js` file.
+
+### Go 1.21
+
+```shell
+docker run -v ${PWD}/go:/opt/go aurelijusbanelis/callenge:go 
+```
+Where your code is in `go` folder with `go/main.go` file.
+
+### Not trusting docker?
+
+Build it yourself:
+```shell
+docker build --target go . -t aurelijusbanelis/callenge:go
+docker build --target php . -t aurelijusbanelis/callenge:php
+docker build --target js . -t aurelijusbanelis/callenge:js
+```
+
+See [Dockerfile](Dockerfile) and [GitHub Actions](.github/workflows/infrastructure.yml) for details.
+
 ## References
 
 * https://www.nsa.smm.lt/wp-content/uploads/2023/06/2023_IT_VBE_pg-web.pdf - original exam example

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Let's have fun and celebrate Programmer's day with this challenge.
 
 ## Running tests locally
 
+Assuming you have [`docker`](https://docs.docker.com/engine/install/) installed.
+
 ### PHP 8.2
 
 ```shell


### PR DESCRIPTION
Using multistage Docker build to support different interpreter environments: https://github.com/tomas-bareikis/challenge/blob/69e31e1ebe99e8d07875934dcdbe5033ee54cedd/README.md

While tests are in root dir, we need to dockerignore everything else.

Docker artifacts are stored at: https://hub.docker.com/r/aurelijusbanelis/callenge:
![image](https://github.com/tomas-bareikis/challenge/assets/11046422/3ae8de7a-1136-484b-bd3c-7e11d05159d5)
