### PR TITLE
Build docker containers only on master

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -1,6 +1,9 @@
 name: Building docker images to run challenge locally
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
For security reasons.
As we expect many Pull requests
and do not want to click "Approve"